### PR TITLE
refactor sequential analysis scripts in scripts/test to improve readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+testsuite/
+tools/gcc/gcc-*.tar.gz
+tools/gcc/gcc-*/
+tools/redis/redis-*/
+tools/redis/redis.tar.gz
+vmm/install/
+vmm/src/roms/seabios
+vmm/src/roms/vgabios

--- a/scripts/test/mem-dict-generation.py
+++ b/scripts/test/mem-dict-generation.py
@@ -9,6 +9,19 @@ import pickle
 import resource
 from datetime import datetime
 
+ACCESS_TYPE_WRITE = 0
+ACCESS_TYPE_READ  = 1
+
+KERNEL_ADDR_MIN = 0xC0000000
+
+BIT_LENGTH_8 = 8
+BIT_LENGTH_16 = 16
+BIT_LENGTH_32 = 32
+
+BYTE_INDEX_8BIT = 0
+BYTE_INDEX_16BIT = 1
+BYTE_INDEX_32BIT = 2
+
 def getFileName(path, prefix, postfix):
     target_list = []
 
@@ -38,7 +51,41 @@ def read_ins_new_dict():
     return defaultdict(read_ins_list)
 
 def access_dict():
-    return [[defaultdict(write_ins_new_dict), defaultdict(write_ins_new_dict), defaultdict(write_ins_new_dict)], [defaultdict(read_ins_new_dict), defaultdict(read_ins_new_dict), defaultdict(read_ins_new_dict)]]
+    return [[defaultdict(write_ins_new_dict), defaultdict(write_ins_new_dict), defaultdict(write_ins_new_dict)], 
+            [defaultdict(read_ins_new_dict), defaultdict(read_ins_new_dict), defaultdict(read_ins_new_dict)]]
+
+def process_memory_access(contents, mem_dict, seed, set_limit, access_type):
+    ins = int(contents[0], 16)
+    addr = int(contents[1], 16)
+    if addr < KERNEL_ADDR_MIN:
+        return
+    value = int(contents[2], 16)
+    bits = int(contents[3])
+    
+    if bits == BIT_LENGTH_8:
+        byte_index = BYTE_INDEX_8BIT
+    elif bits == BIT_LENGTH_16:
+        byte_index = BYTE_INDEX_16BIT
+    elif bits == BIT_LENGTH_32:
+        byte_index = BYTE_INDEX_32BIT
+    else:
+        return  #invalid bit length
+    
+    if access_type == ACCESS_TYPE_READ:
+        double_read = int(contents[5])
+        mem_dict[addr][access_type][byte_index][ins][value][double_read][0] += 1
+        if len(mem_dict[addr][access_type][byte_index][ins][value][double_read][1]) < set_limit:
+            mem_dict[addr][access_type][byte_index][ins][value][double_read][1].add(int(seed))
+    else: #access_type == ACCESS_TYPE_WRITE
+        mem_dict[addr][access_type][byte_index][ins][value][0] += 1
+        if len(mem_dict[addr][access_type][byte_index][ins][value][1]) < set_limit:
+            mem_dict[addr][access_type][byte_index][ins][value][1].add(int(seed))
+
+def process_write_access(contents, mem_dict, seed, set_limit):
+    process_memory_access(contents, mem_dict, seed, set_limit, ACCESS_TYPE_WRITE)
+
+def process_read_access(contents, mem_dict, seed, set_limit):
+    process_memory_access(contents, mem_dict, seed, set_limit, ACCESS_TYPE_READ)
 
 def mem_dict_generation(path, seeds, old_mem_dict=None):
     set_limit = 10
@@ -52,78 +99,50 @@ def mem_dict_generation(path, seeds, old_mem_dict=None):
         if seed.is_dir() is not True:
             continue
         test_list.append(seed.name)
-    random.shuffle(test_list)
+    random.shuffle(test_list)   
     finished = 0
-    for f in test_list:
-        seed = f
+    for seed_dir in test_list:
+        seed = seed_dir
         if int(seed) not in seeds:
             print(seed + ' is not interesting for us')
             continue
-        current_path = path + '/' + f
-        write_set_name = getFileName(current_path, 'write', 'txt')
-        read_set_name = getFileName(current_path, 'read', 'txt')
-        allSets = [current_path + '/' + write_set_name, current_path + '/' + read_set_name]
-        #for index in range(0, 2):
-        write_file = open(allSets[0], 'r')
+        current_path = os.path.join(path, seed)
+        process_seed_file(current_path, seed, mem_dict, set_limit)
+        finished += 1
+        print("Finished adding test " + str(seed), finished, len(test_list))
+    
+    return mem_dict
+
+def process_seed_file(current_path, seed, mem_dict, set_limit):
+    write_set_name = getFileName(current_path, 'write', 'txt')
+    read_set_name = getFileName(current_path, 'read', 'txt')
+    
+    write_file_path = os.path.join(current_path, write_set_name)
+    read_file_path = os.path.join(current_path, read_set_name)
+    
+    with open(write_file_path, 'r') as write_file:
         for line in write_file:
             contents = line.strip().split(' ')
             try:
-                ins = int(contents[0], 16)
-                addr = int(contents[1], 16)
-                if addr < 0xC0000000:
-                    continue
-                value = int(contents[2], 16)
-                bits = int(contents[3])
-                if bits == 8:
-                    mem_dict[addr][0][0][ins][value][0] += 1
-                    if len(mem_dict[addr][0][0][ins][value][1]) < set_limit:
-                        mem_dict[addr][0][0][ins][value][1].add(int(seed))
-                elif bits == 16:
-                    mem_dict[addr][0][1][ins][value][0] += 1
-                    if len(mem_dict[addr][0][1][ins][value][1]) < set_limit:
-                        mem_dict[addr][0][1][ins][value][1].add(int(seed))
-                elif bits == 32:
-                    mem_dict[addr][0][2][ins][value][0] += 1
-                    if len(mem_dict[addr][0][2][ins][value][1]) < set_limit:
-                        mem_dict[addr][0][2][ins][value][1].add(int(seed))
+                process_write_access(contents, mem_dict, seed, set_limit)
             except Exception as e:
                 print("Unexpected error:", sys.exc_info()[0])
                 print(str(e))
                 print("Error happens at line ", line)
                 continue
-        read_file = open(allSets[1], 'r')
+
+    with open(read_file_path, 'r') as read_file:
         for line in read_file:
             contents = line.strip().split(' ')
             try:
-                ins = int(contents[0], 16)
-                addr = int(contents[1], 16)
-                if addr < 0xC0000000:
-                    continue
-                value = int(contents[2], 16)
-                bits = int(contents[3])
-                double_read = int(contents[5])
-                if bits == 8:
-                    mem_dict[addr][1][0][ins][value][double_read][0] += 1
-                    if len(mem_dict[addr][1][0][ins][value][double_read][1]) < set_limit:
-                        mem_dict[addr][1][0][ins][value][double_read][1].add(int(seed))
-                elif bits == 16:
-                    mem_dict[addr][1][1][ins][value][double_read][0] += 1
-                    if len(mem_dict[addr][1][1][ins][value][double_read][1]) < set_limit:
-                        mem_dict[addr][1][1][ins][value][double_read][1].add(int(seed))
-                elif bits == 32:
-                    mem_dict[addr][1][2][ins][value][double_read][0] += 1
-                    if len(mem_dict[addr][1][2][ins][value][double_read][1]) < set_limit:
-                        mem_dict[addr][1][2][ins][value][double_read][1].add(int(seed))
+                process_read_access(contents, mem_dict, seed, set_limit)
             except:
                 print("Error happens at line ", line)
-        finished += 1
-        print("Finished adding test " + str(f), finished, len(test_list))
-    return mem_dict
 
 def reduce_size(mem_dict):
     vma_list = list(mem_dict)
     for vma in vma_list:
-        if vma < 0xC0000000:
+        if vma < KERNEL_ADDR_MIN:
             del mem_dict[vma]
     return mem_dict
 
@@ -133,24 +152,21 @@ def reduce_size(mem_dict):
 # sys.argv[4] existing mem_dict file (optional)
 if __name__ == '__main__':
     data_path = sys.argv[1]
+    
+    interesting_seed =[]
+    for index in range(int(sys.argv[2]), int(sys.argv[3])):
+        interesting_seed.append(index)
+        
     if len(sys.argv) == 5:
         mem_dict_file = open(sys.argv[4], 'rb')
         print("There is an existing mem_dict")
         print("Start to load mem_dict into memory")
         existing_mem_dict = pickle.load(mem_dict_file)
         print("mem_dict is loaded")
-    old_method = False
-    if old_method:
-        interesting_seed = redundant_check(data_path, 3)
-        mem_dict = small_load_interesting(data_path, interesting_seed)
+        mem_dict = mem_dict_generation(data_path, interesting_seed, existing_mem_dict)
     else:
-        interesting_seed =[]
-        for index in range(int(sys.argv[2]), int(sys.argv[3])):
-            interesting_seed.append(index)
-        if len(sys.argv) == 5:
-            mem_dict = mem_dict_generation(data_path, interesting_seed, existing_mem_dict)
-        else:
-            mem_dict = mem_dict_generation(data_path, interesting_seed)
+        mem_dict = mem_dict_generation(data_path, interesting_seed)
+    
     time_now = datetime.now()
     timestamp = time_now.strftime("%Y-%m-%d-%H-%M-%S")
     mem_dict_name = "/../mem-dict-" + timestamp

--- a/scripts/test/mem-dict-generation.py
+++ b/scripts/test/mem-dict-generation.py
@@ -1,4 +1,40 @@
 #!/usr/bin/python3
+"""
+Memory Dictionary Generation Tool
+
+This script processes shared memory access trace files to build a dictionary of 
+memory operations. It reads access trace files (write.txt and read.txt) from multiple 
+test seeds, tracks memory operations, and identifies double read patterns. 
+The created pickle memory dictionary is the input of the PMC analysis script.
+
+input:
+- write.txt: records memory write operations found by sequential-shared-analysis.py. 
+  Format:
+    "<instruction_ptr> <mem_address> <value> <length> <type: 0=write>"
+
+- read.txt:  records memory read operations with double read flags. 
+  Format:
+    "<instruction_ptr> <mem_address> <value> <length> <type: 1=read> <double_read: bool{0,1}>"
+
+output:
+- mem-dict-<timestamp>: pickle file memory dictionary formatted as:
+    "mem_dict[addr][access_type][byte_length][instruction_ptr][value] -> [frequency, seed_set]"
+    where:
+    - addr: memory address accessed (only kernel addresses >= 0xC0000000)
+    - access_type: 0 for write, 1 for read
+    - byte_length: 0 for 8-bit, 1 for 16-bit, 2 for 32-bit access
+    - instruction_ptr: instruction pointer that performed the memory operation
+    - value: value read from or written to memory
+    - stored data includes operation [frequency] and a [seed_set]
+    
+    for reads, double reads are also added:
+    "mem_dict[addr][1][byte_length][instruction_ptr][value][double_read] -> [frequency, seed_set]"
+    where double_read: 0 for normal reads, 1 for double reads
+
+usage:
+  python mem-dict-generation.py [data_path] [seed_start] [seed_end] [existing_mem_dict_file (optional)]
+"""
+
 import sys
 import os
 import multiprocessing

--- a/scripts/test/pmc-analysis.py
+++ b/scripts/test/pmc-analysis.py
@@ -1,4 +1,69 @@
 #!/usr/bin/python3
+"""
+Processor Memory Communication (PMC) Analysis Tool
+
+This script analyzes memory access patterns to identify potential memory channels (PMCs). 
+It processes memory access data to detect different types of PMCs, such as unaligned accesses, 
+double reads, and null object accesses. The analysis is parallelized to efficiently handle 
+large memory trace data.
+
+input:
+- mem-dict-<timestamp>: pickle file that contains memory access data with read/write info.
+  The dictionary maps memory addresses to access data, and contains instruction pointers, 
+  memory values, and access types.
+
+output:
+- uncommon-channel.txt: 
+    all potential memory communications (PMCs) sorted by frequency, 
+    representing shared memory access patterns where one thread writes to a location and 
+    another reads from it. 
+    Format:
+    "<writer_instruction_addr> <writer_memory_addr> <write_byte_length> <reader_instruction_addr> 
+    <reader_memory_addr> <read_byte_length> <frequency>"
+
+- uncommon-unaligned-channel.txt: 
+    PMCs where memory access ranges differ between reader 
+    and writer (different start addresses or lengths), which can cause bugs when readers 
+    fetch partially updated data. 
+    Format:
+    "<writer_instruction_addr> <writer_memory_addr> <write_byte_length> <reader_instruction_addr> 
+    <reader_memory_addr> <read_byte_length> <frequency>"
+
+- uncommon-double-read-channel.txt: 
+    PMCs involving double-fetch patterns where the same 
+    memory location is read twice in sequence, which can lead to time-of-check-to-time-of-use 
+    vulnerabilities. 
+    Format:
+    "<writer_instruction_addr> <writer_memory_addr> <write_byte_length> <reader_instruction_addr> 
+    <reader_memory_addr> <read_byte_length> <double_read_flag> <frequency>"
+
+- uncommon-object-null-channel.txt: 
+    PMCs where a writer zeros out a shared object (writing value 0)
+    that a reader later accesses, often leading to null pointer dereference bugs. 
+    Format:
+    "<writer_instruction_addr> <writer_memory_addr> <write_byte_length> <reader_instruction_addr> 
+    <reader_memory_addr> <read_byte_length> <frequency>"
+
+- uncommon-ins-pair.txt: write-read instruction pairs involved in PMCs, highlighting 
+    specific code patterns that may trigger concurrency bugs. 
+    Format:
+    "<writer_instruction_addr> <reader_instruction_addr> <frequency>"
+
+- uncommon-ins.txt: individual instructions (both reads and writes) participating in PMCs, 
+    sorted by frequency to identify potentially vulnerable code. 
+    Format:
+    "<instruction_addr> <instruction_type{0=write,1=read}> <frequency>"
+
+- uncommon-mem-addr.txt: memory regions where inter-thread communication occurs, 
+    helping identify shared kernel objects prone to race conditions. Format:
+    "<writer_memory_addr> <reader_memory_addr> <write_byte_length> <read_byte_length> <frequency>"
+
+each output file follows a specific format documenting the memory communications detected
+
+usage:
+  python pmc-analysis.py [memory_dict_file] [output_path]
+"""
+
 import sys
 import random
 import os
@@ -9,6 +74,50 @@ import pickle
 import time
 from datetime import datetime
 import struct
+
+class Channel:
+    def __init__(self, write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, double_read=0, write_value_non_zero=0):
+        self.write_ins = write_ins
+        self.write_addr = write_addr
+        self.write_byte = write_byte
+        self.read_ins = read_ins
+        self.read_addr = read_addr
+        self.read_byte = read_byte
+        self.double_read = double_read
+        self.write_value_non_zero = write_value_non_zero
+        
+    def __hash__(self):
+        return hash((self.write_ins, self.write_addr, self.write_byte, 
+                    self.read_ins, self.read_addr, self.read_byte,
+                    self.double_read, self.write_value_non_zero))
+    
+    def __eq__(self, other):
+        if not isinstance(other, Channel):
+            return False
+        return (self.write_ins, self.write_addr, self.write_byte, 
+                self.read_ins, self.read_addr, self.read_byte,
+                self.double_read, self.write_value_non_zero) == \
+               (other.write_ins, other.write_addr, other.write_byte, 
+                other.read_ins, other.read_addr, other.read_byte,
+                other.double_read, other.write_value_non_zero)
+                
+    def get_channel_redux_key(self):
+        #reduced tuple, analysis often disregards double_read and write_value_non_zero
+        return (self.write_ins, self.write_addr, self.write_byte, 
+                self.read_ins, self.read_addr, self.read_byte)
+
+def create_channel_from_redux_key(channel_redux_key):
+    if len(channel_redux_key) >= 6:
+        write_ins, write_addr, write_byte, read_ins, read_addr, read_byte = channel_redux_key[:6]
+        double_read = channel_redux_key[6] if len(channel_redux_key) > 6 else 0
+        write_value_non_zero = channel_redux_key[7] if len(channel_redux_key) > 7 else 0
+        return Channel(write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, double_read, write_value_non_zero)
+    else:
+        raise ValueError("channel_redux_key tuple must have at least 6 elements")
+
+############################
+# PARALLELIZED ANALYSIS    #
+############################
 
 def write_ins_list():
     return [0, set([])]
@@ -23,7 +132,15 @@ def read_ins_new_dict():
     return defaultdict(read_ins_list)
 
 def access_dict():
-    return [[defaultdict(write_ins_new_dict), defaultdict(write_ins_new_dict), defaultdict(write_ins_new_dict)], [defaultdict(read_ins_new_dict), defaultdict(read_ins_new_dict), defaultdict(read_ins_new_dict)]]
+    #create a nested structure of defaultdicts
+    #first level:  read/write distinction [0=write, 1=read]
+    #second level: byte length buckets [0,1,2]
+    #third level:  appropriate dict type
+    result = [
+        [defaultdict(write_ins_new_dict) for _ in range(3)],  # write access
+        [defaultdict(read_ins_new_dict) for _ in range(3)]    # read access
+    ]
+    return result
 
 def partition(origin_list, n):
     if len(origin_list) % n == 0:
@@ -33,7 +150,7 @@ def partition(origin_list, n):
     for i in range(0, n):
         yield origin_list[i*cnt:(i+1)*cnt]
 
-def counting_frequency(shared_mem_addr_list, process_id, result_path):
+def initialize_counting(process_id, result_path):
     if verbose_mode:
         log_filename = result_path + '/PMC-' + str(process_id) +'.txt'
         raw_pmc_list_file = open(log_filename, 'w')
@@ -41,6 +158,92 @@ def counting_frequency(shared_mem_addr_list, process_id, result_path):
     num_pmc = 0
     finished_mem_addr = 0
     channel_freq = defaultdict(int)
+    return access_index_to_byte, num_pmc, finished_mem_addr, channel_freq
+
+def get_memory_access_sets(addr_begin, addr_end, read_addr_begin, read_addr_end):
+    write_addr_set = set([])
+    read_addr_set = set([])
+    for addr in range(addr_begin, addr_end + 1):
+        write_addr_set.add(addr)
+    for addr in range(read_addr_begin, read_addr_end + 1):
+        read_addr_set.add(addr)
+    return write_addr_set, read_addr_set
+
+def calculate_address_overlap(write_addr_begin, write_addr_end, read_addr_begin, read_addr_end):
+    write_addr_set, read_addr_set = get_memory_access_sets(write_addr_begin, write_addr_end, read_addr_begin, read_addr_end)
+    if len(write_addr_set & read_addr_set) == 0:
+        return None
+    addr_begin              = min(list(write_addr_set & read_addr_set))
+    addr_end                = max(list(write_addr_set & read_addr_set))
+    read_begin_offset       = addr_begin - read_addr_begin
+    read_end_offset         = addr_end   - read_addr_begin  + 1
+    write_begin_offset      = addr_begin - write_addr_begin
+    write_end_offset        = addr_end   - write_addr_begin + 1
+    return read_begin_offset, read_end_offset, write_begin_offset, write_end_offset
+
+def process_read_candidate(candidate_index, write_value, write_candidate_list, read_candidate_list, write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, channel_freq):
+    if read_candidate_list[candidate_index][0] == 0:
+        return 0
+    freq = write_candidate_list[0] * read_candidate_list[candidate_index][0]
+    if freq == 0:
+        return 0
+    write_value_flag = 1 if write_value != 0 else 0
+    channel = Channel(write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, candidate_index, write_value_flag)
+    if channel not in channel_freq:
+        channel_freq[channel] = 0
+    channel_freq[channel] += freq
+    if verbose_mode:
+        print(hex(channel.write_ins), hex(channel.write_addr), channel.write_byte, hex(channel.read_ins), hex(channel.read_addr), channel.read_byte, channel.double_read, channel.write_value_non_zero)
+    return 1
+
+def process_value_pair(write_value, read_value, write_bytes_value, read_bytes_value, read_begin_offset, read_end_offset, write_begin_offset, write_end_offset, write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, write_value_dict, read_value_dict, channel_freq):
+    write_actual_value = write_bytes_value[write_begin_offset: write_end_offset]
+    read_actual_value = read_bytes_value[read_begin_offset:read_end_offset]
+    if write_actual_value != read_actual_value:
+        write_candidate_list = write_value_dict[write_value]
+        read_candidate_list = read_value_dict[read_value]
+        num_new_pmc = 0
+        
+        num_new_pmc += process_read_candidate(0, write_value, write_candidate_list, read_candidate_list, 
+                                       write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, channel_freq)
+        
+        num_new_pmc += process_read_candidate(1, write_value, write_candidate_list, read_candidate_list, 
+                                       write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, channel_freq)
+        
+        return num_new_pmc
+    return 0
+
+def process_overlapping_addresses(write_addr, read_addr, write_byte, read_byte, write_ins_dict, read_ins_dict, channel_freq):
+    write_addr_begin = write_addr
+    write_addr_end = write_addr + write_byte - 1
+    read_addr_begin = read_addr
+    read_addr_end = read_addr + read_byte - 1
+    
+    overlap_result = calculate_address_overlap(write_addr_begin, write_addr_end, read_addr_begin, read_addr_end)
+    if not overlap_result:
+        return 0
+        
+    read_begin_offset, read_end_offset, write_begin_offset, write_end_offset = overlap_result
+    num_new_pmc = 0
+    
+    for write_ins in write_ins_dict:
+        for read_ins in read_ins_dict:
+            write_value_dict = write_ins_dict[write_ins]
+            read_value_dict = read_ins_dict[read_ins]
+            for write_value in write_value_dict:
+                write_bytes_value = struct.pack('<I', write_value)
+                for read_value in read_value_dict:
+                    read_bytes_value = struct.pack('<I', read_value)
+                    pmc_count = process_value_pair(write_value, read_value, write_bytes_value, read_bytes_value, 
+                                           read_begin_offset, read_end_offset, write_begin_offset, write_end_offset, 
+                                           write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, 
+                                           write_value_dict, read_value_dict, channel_freq)
+                    num_new_pmc += pmc_count
+    
+    return num_new_pmc
+
+def counting_frequency(shared_mem_addr_list, process_id, result_path):
+    access_index_to_byte, num_pmc, finished_mem_addr, channel_freq = initialize_counting(process_id, result_path)
     num_shared_mem_addr = len(shared_mem_addr_list)
     for write_addr in shared_mem_addr_list:
         if write_addr < 0xC0000000:
@@ -49,104 +252,47 @@ def counting_frequency(shared_mem_addr_list, process_id, result_path):
         write_access_dict = mem_dict[write_addr][0]
         num_new_pmc = 0
         for write_length_index in range(0, 3):
-            # map the length index to real bytes
             write_byte = access_index_to_byte[write_length_index]
-            # if the length is 4 bytes, then the following address would be accessed
-            # addr, addr+1, addr+2, addr+3
             write_addr_begin = write_addr
             write_addr_end = write_addr + write_byte - 1
-            # Now we know the write address and write length
             write_ins_dict = write_access_dict[write_length_index]
-            # enumerate all possible addressed that could overlap with the write access
             for read_addr in range(write_addr_begin - 3, write_addr_end + 1):
                 if read_addr not in shared_mem_addr_set:
                     continue
                 read_access_dict = mem_dict[read_addr][1]
                 for read_length_index in range(0, 3):
                     read_byte = access_index_to_byte[read_length_index]
-                    read_addr_begin = read_addr
-                    read_addr_end = read_addr + read_byte - 1
-                    write_addr_set = set([])
-                    read_addr_set = set([])
-                    for addr in range(write_addr_begin, write_addr_end + 1):
-                        write_addr_set.add(addr)
-                    for addr in range(read_addr_begin, read_addr_end + 1):
-                        read_addr_set.add(addr)
-                    # check if two memory access could overlap
-                    if len(write_addr_set & read_addr_set) == 0:
-                        continue
                     read_ins_dict = read_access_dict[read_length_index]
-                    addr_begin = min(list(write_addr_set & read_addr_set))
-                    addr_end = max(list(write_addr_set & read_addr_set))
-                    read_begin_offset = addr_begin - read_addr_begin
-                    read_end_offset = addr_end - read_addr_begin + 1
-                    write_begin_offset = addr_begin - write_addr_begin
-                    write_end_offset = addr_end - write_addr_begin + 1
-                    for write_ins in write_ins_dict:
-                        for read_ins in read_ins_dict:
-                            write_value_dict = write_ins_dict[write_ins]
-                            read_value_dict = read_ins_dict[read_ins]
-                            for write_value in write_value_dict:
-                                write_bytes_value = struct.pack('<I', write_value)
-                                write_actual_value = write_bytes_value[write_begin_offset: write_end_offset]
-                                for read_value in read_value_dict:
-                                    read_bytes_value = struct.pack('<I', read_value)
-                                    read_actual_value = read_bytes_value[read_begin_offset:read_end_offset]
-                                    if write_actual_value != read_actual_value:
-                                        write_candidate_list = write_value_dict[write_value]
-                                        read_candidate_list = read_value_dict[read_value]
-                                        if read_candidate_list[0][0] != 0:
-                                            freq = write_candidate_list[0] * read_candidate_list[0][0]
-                                            if freq != 0:
-                                                if write_value == 0:
-                                                    channel = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, 0, 0])
-                                                else:
-                                                    # last filed represents the write value is not zero
-                                                    channel = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, 0, 1])
-                                                if channel not in channel_freq:
-                                                    channel_freq[channel] = 0
-                                                channel_freq[channel] += freq
-                                                if verbose_mode:
-                                                    if write_value == 0:
-                                                        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, 0, 0)
-                                                    else:
-                                                        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, 0, 1)
-                                                num_new_pmc += 1
-                                                num_pmc += 1
-                                        if read_candidate_list[1][0] != 0:
-                                            freq = write_candidate_list[0] * read_candidate_list[1][0]
-                                            if freq != 0:
-                                                if write_value == 0:
-                                                    channel = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, 1, 0])
-                                                else:
-                                                    # last filed represents the write value is not zero
-                                                    channel = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, 1, 1])
-                                                if channel not in channel_freq:
-                                                    channel_freq[channel] = 0
-                                                channel_freq[channel] += freq
-                                                if verbose_mode:
-                                                    if write_value == 0:
-                                                        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, 1, 0)
-                                                    else:
-                                                        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, 1, 1)
-                                                num_new_pmc += 1
-                                                num_pmc += 1
+                    current_pmc = process_overlapping_addresses(write_addr, read_addr, write_byte, read_byte, 
+                                                       write_ins_dict, read_ins_dict, channel_freq)
+                    num_new_pmc += current_pmc
+                    num_pmc += current_pmc
         finished_mem_addr += 1
-        print("Process %d analyzed %f (%d/%d) addresses, added %d new PMCs, %d in total" % (process_id,  finished_mem_addr/num_shared_mem_addr, finished_mem_addr, num_shared_mem_addr, num_new_pmc, num_pmc))
+        print("Process %d analyzed %f (%d/%d) addresses, added %d new PMCs, %d in total" % 
+                (process_id, finished_mem_addr/num_shared_mem_addr, finished_mem_addr, 
+                 num_shared_mem_addr, num_new_pmc, num_pmc))
     return channel_freq
 
+#####################################
+# PREPARE AND PARALLELIZE ANALYSIS  #
+#####################################
 
-def pmc_analysis(output, testing_mode):
+def setup_output_directory(output_path):
     time_now = datetime.now()
     timestamp = time_now.strftime("%Y-%m-%d-%H-%M-%S")
-    output_dir = output + '/PMC-' + timestamp + '/'
+    output_dir = output_path + '/PMC-' + timestamp + '/'
     if not os.path.isdir(output_dir):
         os.makedirs(output_dir)
-    time_start = time.time()
+    return output_dir
+
+def prepare_memory_addresses(testing_mode):
     shared_mem_addr_list = list(mem_dict.keys())
     random.shuffle(shared_mem_addr_list)
     if testing_mode:
         shared_mem_addr_list = shared_mem_addr_list[0:50000]
+    return shared_mem_addr_list
+
+def run_parallel_analysis(shared_mem_addr_list, output_dir):
     # divide the task into even pieces
     num_shared_mem_addr = len(shared_mem_addr_list)
     num_process = multiprocessing.cpu_count()
@@ -166,183 +312,165 @@ def pmc_analysis(output, testing_mode):
     for index in range(0, num_process):
         ret = process_pool.apply_async(counting_frequency, args=(task_list[index], index, raw_multiprocess_output_dir))
         each_freq_dict_result.append(ret)
+        
     process_pool.close()
     process_pool.join()
+    return each_freq_dict_result
+
+def combine_results(each_freq_dict_result):
     channel_freq = each_freq_dict_result[0].get()
-    for index in range(1, num_process):
+    for index in range(1, len(each_freq_dict_result)):
         local_channel_freq = each_freq_dict_result[index].get()
         local_keys = set(local_channel_freq.keys())
         global_keys = set(channel_freq.keys())
         assert(global_keys.isdisjoint(local_keys) == True)
         for channel in list(local_keys):
             channel_freq[channel] = local_channel_freq[channel]
+    return channel_freq
+
+#####################################
+# SAVE ANALYSIS RESULTS             #
+#####################################
+
+def save_uncommon_pmc_channels(output_dir, sorted_channel):
+    print("Saving uncommon PMC channels")
+    output_file = open(output_dir + '/uncommon-channel.txt', 'w')
+    reg_channel_freq = defaultdict(int)
+    
+    for channel, freq in sorted_channel:
+        channel_redux_key = channel.get_channel_redux_key()
+        reg_channel_freq[channel_redux_key] += freq
+        
+    sorted_reg_channel = sorted(reg_channel_freq.items(), key=lambda x: x[1])
+    
+    for channel_redux_key, freq in sorted_reg_channel:
+        channel = create_channel_from_redux_key(channel_redux_key)
+        print(hex(channel.write_ins), hex(channel.write_addr), channel.write_byte, 
+              hex(channel.read_ins), hex(channel.read_addr), channel.read_byte, 
+              freq, file=output_file)
+              
+    return sorted_reg_channel
+
+def save_uncommon_unaligned_channels(output_dir, sorted_reg_channel):
+    print("Saving uncommon PMC unaligned-channels")
+    output_file = open(output_dir + '/uncommon-unaligned-channel.txt', 'w')
+    
+    for channel_redux_key, freq in sorted_reg_channel:
+        channel = create_channel_from_redux_key(channel_redux_key)
+        if channel.write_addr == channel.read_addr and channel.write_byte == channel.read_byte:
+            continue
+            
+        print(hex(channel.write_ins), hex(channel.write_addr), channel.write_byte, 
+              hex(channel.read_ins), hex(channel.read_addr), channel.read_byte, 
+              freq, file=output_file)
+
+def save_uncommon_double_read_channels(output_dir, sorted_channel):
+    print("Saving uncommon double-read channels")
+    output_file = open(output_dir + '/uncommon-double-read-channel.txt', 'w')
+    double_channel_freq = defaultdict(int)
+    
+    for channel, freq in sorted_channel:
+        if channel.double_read == 0:
+            continue
+        
+        # create a key that only considers the 6 core attributes plus double_read
+        # this ignores write_value_non_zero for grouping purposes
+        key_tuple = (channel.write_ins, channel.write_addr, channel.write_byte,
+                     channel.read_ins, channel.read_addr, channel.read_byte,
+                     channel.double_read)
+        double_channel_freq[key_tuple] += freq
+        
+    sorted_double_channel = sorted(double_channel_freq.items(), key=lambda x: x[1])
+    
+    for key_tuple, freq in sorted_double_channel:
+        write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, double_read = key_tuple
+        print(hex(write_ins), hex(write_addr), write_byte, 
+              hex(read_ins), hex(read_addr), read_byte, 
+              double_read, freq, file=output_file)
+
+def save_uncommon_object_null_channels(output_dir, sorted_channel):
+    print("Saving uncommon object null channels")
+    output_file = open(output_dir + '/uncommon-object-null-channel.txt', 'w')
+    obj_null_channel_freq = defaultdict(int)
+    
+    for channel, freq in sorted_channel:
+        if channel.write_value_non_zero == 1:
+            continue
+            
+        obj_null_channel_freq[channel] += freq
+        
+    sorted_obj_null_channel = sorted(obj_null_channel_freq.items(), key=lambda x: x[1])
+    
+    for channel, freq in sorted_obj_null_channel:
+        print(hex(channel.write_ins), hex(channel.write_addr), channel.write_byte, 
+              hex(channel.read_ins), hex(channel.read_addr), channel.read_byte, 
+              freq, file=output_file)
+
+def save_uncommon_ins_pairs(output_dir, sorted_channel):
+    print("Saving uncommon ins-pairs")
+    output_file = open(output_dir + '/uncommon-ins-pair.txt', 'w')
+    ins_pair_freq = defaultdict(int)
+    
+    for channel, freq in sorted_channel:
+        ins_pair = (channel.write_ins, channel.read_ins)
+        ins_pair_freq[ins_pair] += freq
+        
+    sorted_ins_pair = sorted(ins_pair_freq.items(), key=lambda x: x[1])
+    
+    for (write_ins, read_ins), freq in sorted_ins_pair:
+        print(hex(write_ins), hex(read_ins), freq, file=output_file)
+
+def save_uncommon_ins(output_dir, sorted_channel):
+    print("Saving uncommon ins")
+    output_file = open(output_dir + '/uncommon-ins.txt', 'w')
+    ins_freq = defaultdict(int)
+    
+    for channel, freq in sorted_channel:
+        write_ins_key = (channel.write_ins, 0)
+        read_ins_key = (channel.read_ins, 1)
+        ins_freq[write_ins_key] += freq
+        ins_freq[read_ins_key] += freq
+        
+    sorted_ins = sorted(ins_freq.items(), key=lambda x: x[1])
+    
+    for (ins, ins_type), freq in sorted_ins:
+        print(hex(ins), ins_type, freq, file=output_file)
+
+def save_uncommon_mem_area(output_dir, sorted_channel):
+    print("Saving uncommon mem area")
+    output_file = open(output_dir + '/uncommon-mem-addr.txt', 'w')
+    mem_area_freq = defaultdict(int)
+    
+    for channel, freq in sorted_channel:
+        mem_area_key = (channel.write_addr, channel.read_addr, channel.write_byte, channel.read_byte)
+        mem_area_freq[mem_area_key] += freq
+        
+    sorted_mem_area = sorted(mem_area_freq.items(), key=lambda x: x[1])
+    
+    for (write_addr, read_addr, write_byte, read_byte), freq in sorted_mem_area:
+        print(hex(write_addr), hex(read_addr), write_byte, read_byte, freq, file=output_file)
+#####################################
+# MAIN                              #
+#####################################
+
+def pmc_analysis(output, testing_mode):
+    output_dir = setup_output_directory(output)
+    time_start = time.time()
+    
+    shared_mem_addr_list = prepare_memory_addresses(testing_mode)
+    each_freq_dict_result = run_parallel_analysis(shared_mem_addr_list, output_dir)
+    channel_freq = combine_results(each_freq_dict_result)
     del each_freq_dict_result
     # sort all communications based on their frequency
     sorted_channel = sorted(channel_freq.items(), key = lambda x: x[1])
 
-    print("Saving uncommon PMC channels")
-    output_file = open(output_dir + '/uncommon-channel.txt', 'w')
-    reg_channel_freq = defaultdict(int)
-    for item in sorted_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_ins = channel[3]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        channel_key = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte])
-        if channel_key not in reg_channel_freq:
-            reg_channel_freq[channel_key] = 0
-        reg_channel_freq[channel_key] += item[1]
-    sorted_reg_channel = sorted(reg_channel_freq.items(), key = lambda x: x[1])
-    for item in sorted_reg_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_ins = channel[3]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, item[1], file=output_file)
-
-    print("Saving uncommon PMC unaligned-channels")
-    output_file = open(output_dir + '/uncommon-unaligned-channel.txt', 'w')
-    for item in sorted_reg_channel:
-        channel = list(item[0])
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        if write_addr == read_addr and write_byte == read_byte:
-            continue
-        write_ins = channel[0]
-        read_ins = channel[3]
-        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, item[1], file=output_file)
-
-    print("Saving uncommon double-read channels")
-    output_file = open(output_dir + '/uncommon-double-read-channel.txt', 'w')
-    double_channel_freq = defaultdict(int)
-    for item in sorted_channel:
-        channel = list(item[0])
-        double_read = channel[6]
-        if double_read == 0:
-            continue
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        write_ins = channel[0]
-        read_ins = channel[3]
-        double_channel_key = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, 1])
-        if double_channel_key not in double_channel_freq:
-            double_channel_freq[double_channel_key] = 0
-        double_channel_freq[double_channel_key] += item[1]
-    sorted_double_channel = sorted(double_channel_freq.items(), key = lambda x: x[1])
-    for item in sorted_double_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_ins = channel[3]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        double_read = channel[6]
-        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, double_read, item[1], file=output_file)
-
-    print("Saving uncommon object null channels")
-    output_file = open(output_dir + '/uncommon-object-null-channel.txt', 'w')
-    obj_null_channel_freq = defaultdict(int)
-    for item in sorted_channel:
-        channel = list(item[0])
-        write_value_non_zero = channel[7]
-        if write_value_non_zero == 1:
-            continue
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        write_ins = channel[0]
-        read_ins = channel[3]
-        obj_null_channel_key = tuple([write_ins, write_addr, write_byte, read_ins, read_addr, read_byte, write_value_non_zero])
-        if obj_null_channel_key not in obj_null_channel_freq:
-            obj_null_channel_freq[obj_null_channel_key] = 0
-        obj_null_channel_freq[obj_null_channel_key] += item[1]
-    sorted_obj_null_channel = sorted(obj_null_channel_freq.items(), key = lambda x: x[1])
-    for item in sorted_obj_null_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_ins = channel[3]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        print(hex(write_ins), hex(write_addr), write_byte, hex(read_ins), hex(read_addr), read_byte, item[1], file=output_file)
-
-    print("Saving uncommon ins-pairs")
-    output_file = open(output_dir + '/uncommon-ins-pair.txt', 'w')
-    ins_pair_freq = defaultdict(int)
-    for item in sorted_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        read_ins = channel[3]
-        ins_pair = tuple([write_ins, read_ins])
-        if ins_pair not in ins_pair_freq:
-            ins_pair_freq[ins_pair] = 0
-        ins_pair_freq[ins_pair] += item[1]
-    sorted_ins_pair = sorted(ins_pair_freq.items(), key = lambda x: x[1])
-    for item in sorted_ins_pair:
-        ins_pair_key = list(item[0])
-        write_ins = ins_pair_key[0]
-        read_ins = ins_pair_key[1]
-        print(hex(write_ins), hex(read_ins), item[1], file=output_file)
-
-    print("Saving uncommon ins")
-    output_file = open(output_dir + '/uncommon-ins.txt', 'w')
-    ins_freq = defaultdict(int)
-    for item in sorted_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        read_ins = channel[3]
-        write_ins_key = tuple([write_ins, 0])
-        read_ins_key = tuple([read_ins, 1])
-        if write_ins_key not in ins_freq:
-            ins_freq[write_ins_key] = 0
-        ins_freq[write_ins_key] += item[1]
-        if read_ins_key not in ins_freq:
-            ins_freq[read_ins_key] = 0
-        ins_freq[read_ins_key] += item[1]
-    sorted_ins = sorted(ins_freq.items(), key = lambda x: x[1])
-    for item in sorted_ins:
-        ins_key = list(item[0])
-        ins = ins_key[0]
-        ins_type = ins_key[1]
-        print(hex(ins), ins_type, item[1], file=output_file)
-
-
-    print("Saving uncommon mem area")
-    output_file = open(output_dir + '/uncommon-mem-addr.txt', 'w')
-    mem_area_freq = defaultdict(int)
-    for item in sorted_channel:
-        channel = list(item[0])
-        write_ins = channel[0]
-        write_addr = channel[1]
-        write_byte = channel[2]
-        read_ins = channel[3]
-        read_addr = channel[4]
-        read_byte = channel[5]
-        mem_area_key = tuple([write_addr, read_addr, write_byte, read_byte])
-        if mem_area_key not in mem_area_freq:
-            mem_area_freq[mem_area_key] = 0
-        mem_area_freq[mem_area_key] += item[1]
-    sorted_mem_area = sorted(mem_area_freq.items(), key = lambda x: x[1])
-    for item in sorted_mem_area:
-        mem_area = list(item[0])
-        write_addr = mem_area[0]
-        read_addr = mem_area[1]
-        write_byte = mem_area[2]
-        read_byte = mem_area[3]
-        print(hex(write_addr), hex(read_addr), write_byte, read_byte, item[1], file=output_file)
+    sorted_reg_channel = save_uncommon_pmc_channels(output_dir, sorted_channel)
+    save_uncommon_unaligned_channels(  output_dir, sorted_reg_channel)
+    save_uncommon_double_read_channels(output_dir, sorted_channel)
+    save_uncommon_object_null_channels(output_dir, sorted_channel)
+    save_uncommon_ins_pairs(           output_dir, sorted_channel)
+    save_uncommon_ins(                 output_dir, sorted_channel)
+    save_uncommon_mem_area(            output_dir, sorted_channel)
 
     time_end = time.time()
     print('time cost',time_end-time_start, 's')

--- a/scripts/test/sequential-shared-analysis.py
+++ b/scripts/test/sequential-shared-analysis.py
@@ -1,4 +1,31 @@
 #!/usr/bin/python3
+"""
+Sequential Shared Memory Analysis Tool
+
+This script analyzes CPU trace files (trace_<timestamp>.txt) to identify shared memory access 
+patterns between multiple CPUs. It looks at the recorded reads and writes, and filters out
+stack-related accesses (since these are by definition not shared). Also detects double reads
+(when an address is read a second time briefly after a jump instruction). 
+
+Input:
+- trace.txt: 
+
+Output:
+- write.txt: records memory write operations. Format:
+    "<instruction_ptr> <mem_address> <value> <length> <type: 0=write>"
+- read.txt: records memory read operations with double read flags. Format:
+    "<instruction_ptr> <mem_address> <value> <length> <type: 1=read> <double_read: bool{0,1}>"
+- result.txt: summarizes shared memory accesses. Format:
+    "write <shared_access> <total_access>\n read <shared_access> <double_read_num> <total_access>"
+
+Usage:
+  python sequential-shared-analysis.py [data_path] [seed_start] [seed_end]
+
+Environment variables:
+  KERNEL_DIR: directory containing the kernel disassembly file (vmlinux.onlydisas)
+"""
+
+
 import os
 import sys
 import multiprocessing
@@ -6,6 +33,122 @@ from multiprocessing import Process
 from collections import defaultdict
 import time
 from datetime import datetime
+
+MEMORY_ACCESS_LENGTH = 10
+CPU_STATE_LENGTH     = 15
+STACK_MASK           = 0xFFFFE000
+STACK_SIZE           = 0x2000
+
+class MemoryAccess:
+    def __init__(self, contents):
+        #based on: "### MEM: 0 8049610 8fd9318 2b 1 32 L 6b867318" format
+        #contents = ["###", "MEM:", "0", "8049610", "8fd9318", "2b", "1", "32", "L", "6b867318"]
+        # contents[0] = "###" (format prefix)
+        # contents[1] = "MEM:" (format prefix)
+        # contents[2] = "0" (CPU index)
+        # contents[3] = "8049610" (instruction pointer)
+        # contents[4] = "8fd9318" (memory address)
+        # contents[5] = "2b" (value read/written)
+        # contents[6] = "1" (memory index)
+        # contents[7] = "32" (bit length: 8, 16, or 32)
+        # contents[8] = "L" (access type: 'L' for load/read, 'S' for store/write)
+        # contents[9] = "6b867318" (physical address)
+        if len(contents) >= MEMORY_ACCESS_LENGTH:
+            self.cpu_index          = int(contents[2])
+            self.instruction_ptr    = int(contents[3], 16)
+            self.mem_address        = int(contents[4], 16)
+            self.value              = int(contents[5], 16)
+            self.mem_index          = int(contents[6])
+            self.length             = int(contents[7])
+            self.access_type        =     contents[8]  #L is load, S is store
+            self.phys_addr          = int(contents[9], 16) if len(contents) > 9 else 0
+        else:
+            #fallback to prevent crash
+            self.cpu_index          = 0
+            self.instruction_ptr    = 0
+            self.mem_address        = 0
+            self.value              = 0
+            self.mem_index          = 0
+            self.length             = 0
+            self.access_type        = "U"  #U is unknown
+            self.phys_addr          = 0
+    
+    def to_string(self):
+        return f"{self.instruction_ptr:x} {self.mem_address:x} {self.value:x} {self.length} {1 if self.access_type == 'L' else 0}"
+
+class CPUState:
+    def __init__(self, contents):
+        #based on format: "0 8049610 1020304 8172000 8fd9300 80 bffff780 0 8fd9300 8fc0c40 73 7b 7b f5d2000 ff801000"
+        # contents[0] = "0" (CPU index)
+        # contents[1] = "8049610" (EIP - instruction pointer)
+        # contents[2] = "1020304" (EAX register)
+        # contents[3] = "8172000" (EBX register)
+        # contents[4] = "8fd9300" (ECX register)
+        # contents[5] = "80" (EDX register)
+        # contents[6] = "bffff780" (ESP register - stack pointer)
+        # contents[7] = "0" (EBP register - base pointer)
+        # contents[8] = "8fd9300" (ESI register)
+        # contents[9] = "8fc0c40" (EDI register)
+        # contents[10] = "73" (CS register - code segment)
+        # contents[11] = "7b" (SS register - stack segment)
+        # contents[12] = "7b" (DS register - data segment)
+        # contents[13] = "f5d2000" (CR3 register - page directory base)
+        # contents[14] = "ff801000" (GDT base)
+        if len(contents) >= CPU_STATE_LENGTH:
+            self.cpu_index  = int(contents[0])
+            self.eip        =     contents[1]  #raw string for dictionary lookups
+            self.eax        = int(contents[2], 16)
+            self.ebx        = int(contents[3], 16)
+            self.ecx        = int(contents[4], 16)
+            self.edx        = int(contents[5], 16)
+            self.esp        = int(contents[6], 16)
+            self.ebp        = int(contents[7], 16)
+            self.esi        = int(contents[8], 16)
+            self.edi        = int(contents[9], 16)
+            self.cs         = int(contents[10], 16)
+            self.ss         = int(contents[11], 16)
+            self.ds         = int(contents[12], 16)
+            self.cr3        = int(contents[13], 16)
+            self.gdt        = int(contents[14], 16)
+        else:
+            #fallback to prevent crash
+            self.cpu_index  = 0
+            self.eip        = 0
+            self.eax        = 0
+            self.ebx        = 0
+            self.ecx        = 0
+            self.edx        = 0
+            self.esp        = 0
+            self.ebp        = 0
+            self.esi        = 0
+            self.edi        = 0
+            self.cs         = 0
+            self.ss         = 0
+            self.ds         = 0
+            self.cr3        = 0
+            self.gdt        = 0
+    
+    def get_stack_range(self):
+        #use ESP register to calculate stack range 
+        #(with 2 constants that should be defined as actual constant vars)
+        stack_begin = self.esp & STACK_MASK
+        stack_end = stack_begin + STACK_SIZE
+        return stack_begin, stack_end
+
+class DisassemblyEntry:
+    def __init__(self, line):
+        # Based on "c1000000:	mov    0x3da9c80,%ecx" format
+        if len(line) > 9 and line[8] == ":":
+            parts = line.split(":", 1)  # Split only on the first colon
+            self.address = parts[0].strip()
+            self.instruction = parts[1].strip()
+        else:
+            self.address = ""
+            self.instruction = ""
+    
+    def is_jump_instruction(self):
+        # Check if the instruction starts with 'j'
+        return self.instruction and self.instruction[0] == 'j'
 
 # Return the filename which matches both the prefiex and postfix
  # Warning: make sure there is only one such file in the folder, otherwise, assertion error
@@ -21,7 +164,7 @@ def getFileName(path, prefix, postfix):
 
     return target_list[0]
 
-def filter_access(seed, data_path, test_list, result_path, logging=True):
+def open_output_files(seed, result_path):
     if not os.path.isdir(result_path + '/' + str(seed)):
         os.makedirs(result_path + '/' + str(seed))
     write_access_filename = result_path + '/' + str(seed) + '/write.txt'
@@ -30,188 +173,266 @@ def filter_access(seed, data_path, test_list, result_path, logging=True):
     write_access_file = open(write_access_filename, 'w')
     read_access_file = open(read_access_filename, 'w')
     result_file = open(result_filename, 'w')
-    total_write = 0
-    shared_write = 0
-    for test_folder in test_list[0]:
-        current_path = data_path + '/cpu0/'+test_folder + '/'
+    
+    return write_access_file, read_access_file, result_file
+
+def get_trace_file_path(seed, test_folder, cpu, data_path):
+    if cpu == 0:
+        current_path = data_path + '/cpu0/' + test_folder + '/'
         target_folder = current_path + str(seed) + '_1/'
-        if os.path.isdir(target_folder):
-            cpu = 0
-            try:
-                exec_filename = getFileName(target_folder, 'trace', 'txt')
-                print(seed, "Found trace file", target_folder+exec_filename)
-            except:
-                print("This test input is corrupted ", current_path)
-                return
-            current_path = target_folder
-            current_cr3 = 0
-            cr3 = 0
-            exec_file = open(current_path + '/' + exec_filename, 'r')
-            exec_content = exec_file.readlines()
-            mem_access_pattern = '# MEM: ' + str(cpu) + ' c'
-            ins_pattern = str(cpu) + ' c'
-            for line_index in range(0, len(exec_content)):
-                line = exec_content[line_index]
-                if line.find(mem_access_pattern) == -1:
-                    if line.startswith(ins_pattern):
-                        contents = line.strip().split(' ')
-                        if len(contents) != 15:
-                            continue
-                        current_cr3 = int(contents[13], 16)
-                        if cr3 == 0:
-                            cr3 = current_cr3
-                        esp_value = int(contents[6], 16)
-                        stack_begin = esp_value & 0xFFFFE000
-                        stack_end = stack_begin + 0x2000
-                elif current_cr3 == cr3:
-                    # this is a memory access emit from the target CPU
-                    contents = line.strip().split(' ')
-                    if len(contents) != 10:
-                        # if the length is not 10, then something is wrong
-                        # but for now we ignore the error
-                        continue
-                    if contents[8] == 'S':
-                        total_write += 1
-                        ins = int(contents[3], 16)
-                        addr = int(contents[4], 16)
-                        if addr >= stack_begin and addr < stack_end:
-                            continue
-                        shared_write += 1
-                        value = int(contents[5], 16)
-                        length = int(contents[7])
-                        type = 0
-                        print(contents[3], contents[4], contents[5], contents[7], type, file=write_access_file)
-                    #print(contents[3], contents[4], contents[5], contents[7], type, file=simple_result_file)
-                    #print(line.strip(), file=result_file)
-                    # this access is "shared"
-    print("write", shared_write, total_write, file=result_file)
-    distance = 10
-    total_read = 0
-    shared_read = 0
+    else:  # cpu == 1
+        current_path = data_path + '/cpu1/' + test_folder + '/'
+        target_folder = current_path + '1_' + str(seed) + '/'
+    
+    if not os.path.isdir(target_folder):
+        return None, None
+    
+    try:
+        exec_filename = getFileName(target_folder, 'trace', 'txt')
+        print(seed, "Found trace file", target_folder+exec_filename)
+        return target_folder, exec_filename
+    except:
+        print("This test input is corrupted ", current_path)
+        return None, None
+
+def process_write_access(seed, test_list, data_path, write_access_file, result_file):
+    process_memory_access(
+        seed=seed, 
+        test_list=test_list[0], 
+        data_path=data_path, 
+        access_file=write_access_file, 
+        result_file=result_file, 
+        cpu=0, 
+        access_type='S'
+    )
+
+def process_read_access(seed, test_list, data_path, read_access_file, result_file):
+    process_memory_access(
+        seed=seed, 
+        test_list=test_list[1], 
+        data_path=data_path, 
+        access_file=read_access_file, 
+        result_file=result_file, 
+        cpu=1, 
+        access_type='L'
+    )
+
+def process_memory_access(seed, test_list, data_path, access_file, result_file, cpu, access_type):
+    """
+    process memory access events from trace files for a specific CPU and access type.
+    
+    args:
+        seed (int): the seed value identifying the test case
+        test_list (list): list of test folders to process
+        data_path (str): base path to the test data
+        access_file (file): open file to write memory access information
+        result_file (file): open file to write summary results
+        cpu (int): CPU identifier (0 (for write) or 1 (for read))
+        access_type (str): type of memory access to process ('S' for store/write, 'L' for load/read)
+    
+    returns:
+        none: results are written to provided files
+    """
+    
+    total_access = 0
+    shared_access = 0
     double_read_num = 0
-    for test_folder in test_list[1]:
-        current_path = data_path + '/cpu1/'+test_folder + '/'
-        target_folder = current_path +'1_' + str(seed) + '/'
-        if os.path.isdir(target_folder):
-            cpu = 1
-            try:
-                exec_filename = getFileName(target_folder, 'trace', 'txt')
-                print(seed, "Found trace file", target_folder+exec_filename)
-            except:
-                print("This test input is corrupted ", current_path)
-                return
-            current_cr3 = 0
-            cr3 = 0
-            current_path = target_folder
-            exec_file = open(current_path + '/' + exec_filename, 'r')
-            exec_content = exec_file.readlines()
-            mem_access_pattern = '# MEM: ' + str(cpu) + ' c'
-            ins_pattern = str(cpu) + ' c'
-            for line_index in range(0, len(exec_content)):
-                line = exec_content[line_index]
-                if line.find(mem_access_pattern) == -1:
-                    if line.startswith(ins_pattern):
-                        contents = line.strip().split(' ')
-                        if len(contents) != 15:
-                            continue
-                        current_cr3 = int(contents[13], 16)
-                        if cr3 == 0:
-                            cr3 = current_cr3
-                        esp_value = int(contents[6], 16)
-                        stack_begin = esp_value & 0xFFFFE000
-                        stack_end = stack_begin + 0x2000
-                elif current_cr3 == cr3:
-                    # this is a memory access emit from the target CPU
-                    contents = line.strip().split(' ')
-                    if len(contents) != 10:
-                        # if the length is not 10, then something is wrong
-                        # but for now we ignore the rror
-                        continue
-                    if contents[8] == 'L':
-                        total_read += 1
-                        ins = int(contents[3], 16)
-                        addr = int(contents[4], 16)
-                        if addr >= stack_begin and addr < stack_end:
-                            continue
-                        shared_read += 1
-                        value = int(contents[5], 16)
-                        length = int(contents[7])
-                        # We need to analyze double read for read access
-                        jump_found = 0
-                        double_read = 0
-                        compare_index_end = line_index + 1 + distance
-                        compare_current_cr3 = cr3
-                        compare_stack_begin = stack_begin
-                        compare_stack_end = stack_end
-                        if compare_index_end > len(exec_content):
-                            compare_index_end = len(exec_content)
-                        for compare_index in range(line_index + 1, compare_index_end):
-                            compare_line = exec_content[compare_index]
-                            if compare_line.find(mem_access_pattern) == -1:
-                                if compare_line.startswith(ins_pattern):
-                                    compare_contents = compare_line.strip().split(' ')
-                                    if len(compare_contents) != 15:
-                                        continue
-                                    compare_current_cr3 = int(compare_contents[13], 16)
-                                    compare_esp_value = int(compare_contents[6], 16)
-                                    compare_stack_begin = compare_esp_value & 0xFFFFE000
-                                    compare_stack_end = compare_stack_begin + 0x2000
-                                    compare_possible_ins = compare_contents[1]
-                                    if len(ip_disas[compare_possible_ins])== 0:
-                                        ## very strange c10d66b2 ins on 2_1, check it later
-                                        continue
-                                    if ip_disas[compare_possible_ins][0] == 'j':
-                                        jump_found = 1
-                            elif compare_current_cr3 == cr3:
-                                compare_contents = compare_line.strip().split(' ')
-                                if len(compare_contents) != 10:
-                                    continue
-                                compare_addr = int(compare_contents[4], 16)
-                                if compare_addr != addr:
-                                    continue
-                                compare_ins = int(compare_contents[3], 16)
-                                compare_value = int(compare_contents[5], 16)
-                                compare_length = int(compare_contents[7])
-                                if jump_found and compare_ins != ins and compare_value == value and compare_length == length:
-                                    double_read = 1
-                                    double_read_num += 1
-                                    break
-                        print(contents[3], contents[4], contents[5], contents[7], 1, double_read, file=read_access_file)
-    print("read", shared_read, double_read_num, total_read, file=result_file)
+    
+    for test_folder in test_list:
+        target_folder, exec_filename = get_trace_file_path(seed, test_folder, cpu, data_path)
+        if not target_folder:
+            continue
+        current_cr3 = 0
+        cr3 = 0
+        current_path = target_folder
+        exec_file = open(current_path + '/' + exec_filename, 'r')
+        exec_content = exec_file.readlines()
+        mem_access_pattern = '# MEM: ' + str(cpu) + ' c'
+        ins_pattern = str(cpu) + ' c'
+        stack_begin = 0
+        stack_end = 0
+        for line_index in range(0, len(exec_content)):
+            line = exec_content[line_index]
+            if line.find(mem_access_pattern) == -1:
+                contents = line.strip().split(' ')
+                if not line.startswith(ins_pattern):
+                    continue
+
+                if len(contents) != CPU_STATE_LENGTH:
+                    continue
+
+                cpu_state = CPUState(contents)
+                current_cr3 = cpu_state.cr3
+                if cr3 == 0:
+                    cr3 = current_cr3
+                stack_begin, stack_end = cpu_state.get_stack_range()
+                continue
+            
+            if current_cr3 != cr3:
+                # cr3: skipping since memory access is not from this process
+                # this is a memory access emit from the target CPU
+                continue
+
+            contents = line.strip().split(' ')
+            if len(contents) != MEMORY_ACCESS_LENGTH:
+                # if the length is not 10, then something is wrong
+                # but for now we ignore the error
+                continue
+
+            mem_access = MemoryAccess(contents)
+            if mem_access.access_type != access_type:
+                continue
+
+            total_access += 1
+            if mem_access.mem_address >= stack_begin and mem_access.mem_address < stack_end:
+                continue
+
+            shared_access += 1
+            if access_type == 'S':  # write access
+                type = 0
+                print(f"{mem_access.instruction_ptr:x} {mem_access.mem_address:x} {mem_access.value:x} {mem_access.length} {type}", file=access_file)
+            else:  # read access
+                double_read = check_double_read(line_index, exec_content, mem_access, 
+                                                    cr3, stack_begin, stack_end, mem_access_pattern, 
+                                                    ins_pattern)
+                if double_read:
+                    double_read_num += 1  
+                print(f"{mem_access.instruction_ptr:x} {mem_access.mem_address:x} {mem_access.value:x} {mem_access.length} 1 {double_read}", file=access_file)
+        exec_file.close()
+    
+    if access_type == 'S':
+        print("write", shared_access, total_access, file=result_file)
+    else:
+        print("read", shared_access, double_read_num, total_access, file=result_file)
+
+def check_double_read(line_index, exec_content, mem_access, cr3, stack_begin, stack_end, mem_access_pattern, ins_pattern):
+    """
+    detect if a memory read operation is followed by another read to the same address after a jump instruction
+    
+    this function examines a window of trace lines after the current memory read to determine if 
+    there's a pattern indicating a "double read" scenario (where the same memory location is read 
+    again after a jump instruction)
+    
+    args:
+        line_index (int): current index in the execution trace
+        exec_content (list): list of all trace file lines
+        mem_access (MemoryAccess): current memory access being checked
+        cr3 (int): current page directory base register value
+        stack_begin (int): start address of current stack
+        stack_end (int): end address of current stack
+        mem_access_pattern (str): pattern to identify memory access lines
+        ins_pattern (str): pattern to identify instruction lines
+        
+    returns:
+        int: 1 if a double read pattern is detected, 0 otherwise
+    """
+    max_double_read_distance = 10
+    jump_found = 0
+    compare_index_end = line_index + 1 + max_double_read_distance
+    compare_current_cr3 = cr3
+    if compare_index_end > len(exec_content):
+        compare_index_end = len(exec_content)
+    
+    for compare_index in range(line_index + 1, compare_index_end):
+        compare_line = exec_content[compare_index]
+
+        if compare_line.find(mem_access_pattern) == -1:
+            if not compare_line.startswith(ins_pattern):
+                continue
+
+            compare_contents = compare_line.strip().split(' ')
+            if len(compare_contents) != CPU_STATE_LENGTH:
+                continue
+
+            cpu_state = CPUState(compare_contents)
+            compare_current_cr3 = cpu_state.cr3
+            compare_possible_ins = cpu_state.eip
+
+            if len(disas_ins_dict[compare_possible_ins]) == 0:
+                ## very strange c10d66b2 ins on 2_1, check it later
+                continue
+
+            if disas_ins_dict[compare_possible_ins][0] == 'j':
+                jump_found = 1
+            continue
+
+        if compare_current_cr3 != cr3:
+            # cr3: skipping since memory access is not from this process
+            continue
+        
+        compare_contents = compare_line.strip().split(' ')
+        if len(compare_contents) != MEMORY_ACCESS_LENGTH:
+            continue
+
+        compare_mem_access = MemoryAccess(compare_contents)
+        if compare_mem_access.mem_address != mem_access.mem_address:
+            continue
+        
+        if (jump_found 
+            and compare_mem_access.instruction_ptr != mem_access.instruction_ptr 
+            and compare_mem_access.value == mem_access.value 
+            and compare_mem_access.length == mem_access.length):
+            return 1 #found a double read
+                
+    return 0 #found no double read
+
+def filter_access(seed, data_path, test_list, result_path, logging=True):
+    write_access_file, read_access_file, result_file = open_output_files(seed, result_path)
+
+    process_write_access(seed, test_list, data_path, write_access_file, result_file)
+
+    process_read_access(seed, test_list, data_path, read_access_file, result_file)
+
+    write_access_file.close()
+    read_access_file.close()
+    result_file.close()
+    
     print("Finished analyzing seed ", seed, " result is saved to ", result_path)
 
-
-
-kernel_dir = os.environ.get('KERNEL_DIR')
-if kernel_dir is None:
-    print("error happens when accessing environment vairable KERNEL_DIR")
-    exit(1)
-linux_disas_filename = kernel_dir + "/vmlinux.onlydisas"
-ip_disas = defaultdict(str)
-linux_disas_file = open(linux_disas_filename, 'r')
-for line in linux_disas_file:
-    if len(line) > 9 and line[8] == ":":
-        contents = line.split(":")
-        ins_addr = contents[0]
-        ip_disas[ins_addr] = contents[1].strip()
-        print(ins_addr, ip_disas[ins_addr])
-
-if __name__ == '__main__':
-    data_path = sys.argv[1]
+def get_test_lists(data_path):
     cpu0_test_list = []
     cpu1_test_list = []
+
     for test in os.scandir(data_path + '/cpu0/'):
         if test.is_dir() is True:
             if test.name.find("test") > -1:
                 cpu0_test_list.append(test.name)
+    
     for test in os.scandir(data_path + '/cpu1/'):
         if test.is_dir() is True:
             if test.name.find("test") > -1:
                 cpu1_test_list.append(test.name)
+    
     test_list = [cpu0_test_list, cpu1_test_list]
     assert(len(cpu0_test_list) == len(cpu1_test_list))
+    
+    return test_list
+
+def load_disassembly_data():
+    kernel_dir = os.environ.get('KERNEL_DIR')
+    if kernel_dir is None:
+        print("error happens when accessing environment vairable KERNEL_DIR")
+        exit(1)
+    linux_disas_filename = kernel_dir + "/vmlinux.onlydisas"
+    ip_disas = defaultdict(str)
+    linux_disas_file = open(linux_disas_filename, 'r')
+    for line in linux_disas_file:
+        disas_entry = DisassemblyEntry(line)
+        if disas_entry.address != "":
+            ip_disas[disas_entry.address] = disas_entry.instruction
+            # print(disas_entry.address, disas_entry.instruction)
+        
+    return ip_disas
+
+disas_ins_dict = load_disassembly_data()
+
+if __name__ == '__main__':
+    data_path = sys.argv[1]
     seed_start = int(sys.argv[2])
     seed_end = int(sys.argv[3])
+
+    test_list = get_test_lists(data_path)
+    
     print("Analyzing sequential tests between ", seed_start, seed_end)
     time_now = datetime.now()
     timestamp = time_now.strftime("%Y-%m-%d-%H-%M-%S")

--- a/scripts/test/sequential-shared-analysis.py
+++ b/scripts/test/sequential-shared-analysis.py
@@ -8,7 +8,10 @@ stack-related accesses (since these are by definition not shared). Also detects 
 (when an address is read a second time briefly after a jump instruction). 
 
 Input:
-- trace.txt: 
+- trace.txt: recorded memory accesses and CPU states.
+  Formats:
+    1. MemoryAccess: "### MEM: <cpu_index> <instruction_ptr> <mem_address> <value> <mem_index> <length (bits)> <access_type: {'L','S'}> <phys_addr>"
+    2. CPUState:     "<cpu_index> <eip> <eax> <ebx> <ecx> <edx> <esp> <ebp> <esi> <edi> <cs> <ss> <ds> <cr3> <gdt>"
 
 Output:
 - write.txt: records memory write operations. Format:


### PR DESCRIPTION
Following a slow start on working with the sequential analysis scripts in scripts/test, I decided to rewrite them for readability. I think the refactoring can help other people too, hence this pull request. I tried to maintain the original code style but made sure to flatten deeply nested code, add helper functions to avoid lengthy functions and code repetitions, and replaced tuple accesses with class accesses. I also added a `.gitignore` to ignore some files generated by `scripts/setup.sh`. I made sure to maintain the exact original functionality and meticulously checked that the final `pmc-analysis.py` outputs the same PMC's. 

It modifies:
- scripts/test/sequential-shared-analysis.py
- scripts/test/mem-dict-generation.py
- scripts/test/pmc-analysis.py

Let me know if you'd like any changes to be made before accepting this pull request. If accepted, then I'm happy to have made a contribution to this project :). 